### PR TITLE
docs: fix code covenant badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Contributions are welcome! Please fork the repository and submit a pull request 
 
 ## Code of Conduct
 
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](.github/CODE_OF_CONDUCT.md)
 
 This project has adopted the code of conduct defined by the Contributor Covenant to clarify expected behavior in our community. For more information see the [Code of Conduct](.github/CODE_OF_CONDUCT.md).
 


### PR DESCRIPTION
since it's using the default file path from https://www.contributor-covenant.org I thought it would be better to point to a local file to avoid 404 errors when navigating through the readme file