### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: .NET Build & Test Workflow
+permissions:
+  contents: read
 on:
   push:
     branches: ["main", "develop"]


### PR DESCRIPTION
Potential fix for [https://github.com/ellosoft/aws-cred-mgr/security/code-scanning/1](https://github.com/ellosoft/aws-cred-mgr/security/code-scanning/1)

To fix the problem, we should explicitly restrict the `GITHUB_TOKEN` permissions for this workflow to the minimal set required. Since the job only checks out code and runs local `.NET` build and test commands, it does not need to write to the repository, issues, or pull requests. Therefore, we can safely set `contents: read` at the workflow level, which will apply to all jobs unless overridden.

The best fix without changing existing functionality is to add a `permissions` block near the top of `.github/workflows/build.yml`, at the root level (same indentation as `on:` and `jobs:`). We don’t need any additional imports or methods because this is a YAML configuration file for GitHub Actions. A minimal and appropriate configuration is:

```yaml
permissions:
  contents: read
```

This documents the intended permissions, constrains the `GITHUB_TOKEN` even if org/repo defaults are broader, and does not interfere with `actions/checkout@v4` or the `dotnet` commands, which only need read access to repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
