### PR TITLE
feat: case-insensitive MFA types and --force-renew

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ aws-cred-mgr okta setup
 
 - Simply run `aws-cred-mgr okta setup` to use interactive mode.
 - Set up with domain and username: `aws-cred-mgr okta setup -d https://xyz.okta.com -u john --mfa push`
+- Prefer Okta Verify app TOTP codes: `aws-cred-mgr okta setup --mfa app`
+- Prefer Okta Verify push (including phone fingerprint approval): `aws-cred-mgr okta setup --mfa fingerprint`
+
+Supported `--mfa` / `preferred_mfa_type` values:
+
+| Value | Okta factor | Experience |
+| --- | --- | --- |
+| `push`, `fingerprint` | Okta Verify push | Approve a push notification (biometric unlock happens in the Okta Verify app) |
+| `totp`, `code`, `app` | Okta Verify TOTP | Enter the 6-digit code from the Okta Verify app |
+
+> [!Note]
+> `fingerprint` maps to Okta Verify **push** (phone biometric). Desktop Okta FastPass / Touch ID / Windows Hello (`signed_nonce`) is not supported yet.
 
 ### Credential Management
 
@@ -75,6 +87,7 @@ aws-cred-mgr cred [COMMAND]
 - Create a new credential profile named `prod`: `aws-cred-mgr cred new prod`
 - List credentials: `aws-cred-mgr cred ls`
 - Get the AWS credentials for `prod` and stores it in ~/.aws/credentials: `aws-cred-mgr cred get prod`
+- Force renew AWS credentials even if the current session is still valid: `aws-cred-mgr cred get prod --force-renew`
 
 ### RDS Token Management
 
@@ -87,6 +100,7 @@ aws-cred-mgr rds [COMMAND]
 - Get RDS password : `aws-cred-mgr rds pwd`
 - Get RDS password for `prod_db`: `aws-cred-mgr rds pwd prod_db`
 - Get RDS password with all options: `aws-cred-mgr rds pwd -h localhost -p 5432 -u john`
+- Force renew the underlying AWS session before generating an RDS password: `aws-cred-mgr rds pwd prod_db --force-renew`
 
 ### Config Files
 
@@ -129,7 +143,7 @@ authentication:
     okta:
         default: # default Okta profile name, additional profiles can also be created
             okta_domain: https://xyz.okta.com/
-            preferred_mfa_type: push
+            preferred_mfa_type: push # also: fingerprint | totp | code | app
             auth_type: classic
 
 credentials:

--- a/README.md
+++ b/README.md
@@ -57,18 +57,6 @@ aws-cred-mgr okta setup
 
 - Simply run `aws-cred-mgr okta setup` to use interactive mode.
 - Set up with domain and username: `aws-cred-mgr okta setup -d https://xyz.okta.com -u john --mfa push`
-- Prefer Okta Verify app TOTP codes: `aws-cred-mgr okta setup --mfa app`
-- Prefer Okta Verify push (including phone fingerprint approval): `aws-cred-mgr okta setup --mfa fingerprint`
-
-Supported `--mfa` / `preferred_mfa_type` values:
-
-| Value | Okta factor | Experience |
-| --- | --- | --- |
-| `push`, `fingerprint` | Okta Verify push | Approve a push notification (biometric unlock happens in the Okta Verify app) |
-| `totp`, `code`, `app` | Okta Verify TOTP | Enter the 6-digit code from the Okta Verify app |
-
-> [!Note]
-> `fingerprint` maps to Okta Verify **push** (phone biometric). Desktop Okta FastPass / Touch ID / Windows Hello (`signed_nonce`) is not supported yet.
 
 ### Credential Management
 
@@ -143,7 +131,7 @@ authentication:
     okta:
         default: # default Okta profile name, additional profiles can also be created
             okta_domain: https://xyz.okta.com/
-            preferred_mfa_type: push # also: fingerprint | totp | code | app
+            preferred_mfa_type: push # also: totp | code
             auth_type: classic
 
 credentials:

--- a/config/sample-config.yml
+++ b/config/sample-config.yml
@@ -6,7 +6,11 @@ authentication:
   okta:
     default:
       okta_domain: https://xyz.okta.com/
+      # preferred_mfa_type accepts: push | fingerprint | totp | code | app
+      # (fingerprint maps to Okta Verify push; app maps to TOTP code entry)
       preferred_mfa_type: push
+      # preferred_mfa_type: app
+      # preferred_mfa_type: fingerprint
       auth_type: classic
 
 credentials:

--- a/config/sample-config.yml
+++ b/config/sample-config.yml
@@ -6,11 +6,7 @@ authentication:
   okta:
     default:
       okta_domain: https://xyz.okta.com/
-      # preferred_mfa_type accepts: push | fingerprint | totp | code | app
-      # (fingerprint maps to Okta Verify push; app maps to TOTP code entry)
       preferred_mfa_type: push
-      # preferred_mfa_type: app
-      # preferred_mfa_type: fingerprint
       auth_type: classic
 
 credentials:

--- a/src/Ellosoft.AwsCredentialsManager/Commands/Credentials/GetCredentials.cs
+++ b/src/Ellosoft.AwsCredentialsManager/Commands/Credentials/GetCredentials.cs
@@ -10,7 +10,8 @@ namespace Ellosoft.AwsCredentialsManager.Commands.Credentials;
 [Description("Get AWS credentials for an existing credential profile")]
 [Examples(
     "get prod",
-    "get prod --aws-profile default")]
+    "get prod --aws-profile default",
+    "get prod --force-renew")]
 public class GetCredentials(
     ICredentialsManager credentialsManager,
     IAwsOktaSessionManager sessionManager
@@ -26,13 +27,17 @@ public class GetCredentials(
         [Description("AWS profile to use (profile used in AWS CLI)")]
         [DefaultValue("default")]
         public string? AwsProfile { get; set; }
+
+        [CommandOption("-f|--force-renew")]
+        [Description("Renew AWS credentials even if the current session is still valid")]
+        public bool ForceRenew { get; set; }
     }
 
     public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         var credential = settings.Credential ?? credentialsManager.GetCredentialNameFromUser();
 
-        var awsCredentials = await sessionManager.CreateOrResumeSessionAsync(credential, settings.AwsProfile);
+        var awsCredentials = await sessionManager.CreateOrResumeSessionAsync(credential, settings.AwsProfile, settings.ForceRenew);
 
         if (awsCredentials is null)
             return 1;

--- a/src/Ellosoft.AwsCredentialsManager/Commands/Okta/SetupOkta.cs
+++ b/src/Ellosoft.AwsCredentialsManager/Commands/Okta/SetupOkta.cs
@@ -30,7 +30,7 @@ public class SetupOkta(IOktaLoginService loginService, IConfigManager configMana
         public string? Username { get; set; }
 
         [CommandOption("--mfa")]
-        [Description("Your preferred MFA type <push|fingerprint|totp|code|app>")]
+        [Description("Your preferred MFA type <push|totp|code>")]
         public string? PreferredMfaType { get; set; }
     }
 

--- a/src/Ellosoft.AwsCredentialsManager/Commands/Okta/SetupOkta.cs
+++ b/src/Ellosoft.AwsCredentialsManager/Commands/Okta/SetupOkta.cs
@@ -30,7 +30,7 @@ public class SetupOkta(IOktaLoginService loginService, IConfigManager configMana
         public string? Username { get; set; }
 
         [CommandOption("--mfa")]
-        [Description("Your prefered MFA type <push|totp (code)>")]
+        [Description("Your preferred MFA type <push|fingerprint|totp|code|app>")]
         public string? PreferredMfaType { get; set; }
     }
 

--- a/src/Ellosoft.AwsCredentialsManager/Commands/RDS/GetRdsPassword.cs
+++ b/src/Ellosoft.AwsCredentialsManager/Commands/RDS/GetRdsPassword.cs
@@ -15,7 +15,8 @@ namespace Ellosoft.AwsCredentialsManager.Commands.RDS;
 [Description("Get AWS RDS DB password")]
 [Examples(
     "pwd prod_db",
-    "pwd -h localhost -p 5432 -u john")]
+    "pwd -h localhost -p 5432 -u john",
+    "pwd prod_db --force-renew")]
 public class GetRdsPassword(
     IConfigManager configManager,
     IEnvironmentManager envManager,
@@ -51,6 +52,10 @@ public class GetRdsPassword(
         [CommandOption("--env")]
         [Description("Environment name")]
         public string? Environment { get; set; }
+
+        [CommandOption("-f|--force-renew")]
+        [Description("Renew AWS credentials even if the current session is still valid")]
+        public bool ForceRenew { get; set; }
     }
 
     public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
@@ -68,7 +73,8 @@ public class GetRdsPassword(
             dbConfig.Port,
             dbConfig.Username,
             dbConfig.Region,
-            dbConfig.GetTtl()
+            dbConfig.GetTtl(),
+            settings.ForceRenew
         );
 
         return 0;
@@ -85,14 +91,14 @@ public class GetRdsPassword(
         var username = settings.Username ?? await AnsiConsole.AskAsync<string>("Enter the DB username:");
         var region = settings.GetRegion();
 
-        await GenerateDbPassword(credentialName, hostname, port, username, region.SystemName, settings.Ttl);
+        await GenerateDbPassword(credentialName, hostname, port, username, region.SystemName, settings.Ttl, settings.ForceRenew);
 
         CreateNewRdsProfile(credentialName, hostname, port, username, settings.Ttl, region.SystemName, settings.Environment);
 
         return 0;
     }
 
-    private async Task GenerateDbPassword(string? credential, string? hostname, int? port, string? username, string? region, int ttl)
+    private async Task GenerateDbPassword(string? credential, string? hostname, int? port, string? username, string? region, int ttl, bool forceRenew = false)
     {
         try
         {
@@ -102,7 +108,7 @@ public class GetRdsPassword(
             ArgumentNullException.ThrowIfNull(username);
             ArgumentNullException.ThrowIfNull(region);
 
-            var awsCredentials = await awsSessionManager.CreateOrResumeSessionAsync(credential, null);
+            var awsCredentials = await awsSessionManager.CreateOrResumeSessionAsync(credential, null, forceRenew);
 
             if (awsCredentials is null)
                 throw new CommandException($"Unable to resume or create AWS session for credential '{credential}'");

--- a/src/Ellosoft.AwsCredentialsManager/Services/AWS/Interactive/AwsOktaSessionManager.cs
+++ b/src/Ellosoft.AwsCredentialsManager/Services/AWS/Interactive/AwsOktaSessionManager.cs
@@ -10,7 +10,7 @@ namespace Ellosoft.AwsCredentialsManager.Services.AWS.Interactive;
 
 public interface IAwsOktaSessionManager
 {
-    Task<AWSCredentials?> CreateOrResumeSessionAsync(string credentialProfile, string? outputAwsProfile);
+    Task<AWSCredentials?> CreateOrResumeSessionAsync(string credentialProfile, string? outputAwsProfile, bool forceRenew = false);
 }
 
 public class AwsOktaSessionManager(
@@ -20,14 +20,14 @@ public class AwsOktaSessionManager(
     IAwsCredentialsService awsCredentialsService,
     IAwsSamlService awsSamlService) : IAwsOktaSessionManager
 {
-    public async Task<AWSCredentials?> CreateOrResumeSessionAsync(string credentialProfile, string? outputAwsProfile)
+    public async Task<AWSCredentials?> CreateOrResumeSessionAsync(string credentialProfile, string? outputAwsProfile, bool forceRenew = false)
     {
         if (!credentialsManager.TryGetCredential(credentialProfile, out var credentialsConfig))
             return null;
 
         var awsProfile = credentialsConfig.GetAwsProfileSafe(credentialProfile);
 
-        if (TryResumeSession(awsProfile, credentialsConfig.RoleArn, out var awsCredentialsData))
+        if (!forceRenew && TryResumeSession(awsProfile, credentialsConfig.RoleArn, out var awsCredentialsData))
             return CreateAwsCredentials(awsCredentialsData, awsProfile, outputAwsProfile);
 
         var newCredential = await CreateSessionAsync(credentialProfile, awsProfile, credentialsConfig);

--- a/src/Ellosoft.AwsCredentialsManager/Services/Okta/Interactive/OktaMfaFactorSelector.cs
+++ b/src/Ellosoft.AwsCredentialsManager/Services/Okta/Interactive/OktaMfaFactorSelector.cs
@@ -32,11 +32,11 @@ public class OktaMfaFactorSelector : IOktaMfaFactorSelector
 
     public static string GetOktaMfaFactorCode(string simplifiedMfaName)
     {
-        return simplifiedMfaName switch
+        return simplifiedMfaName.ToLowerInvariant() switch
         {
-            "push" => "push",
-            "totp" => "token:software:totp",
-            "code" => "token:software:totp",
+            "push" or "fingerprint" => "push",
+            "totp" or "code" or "app" => "token:software:totp",
+            "token:software:totp" => "token:software:totp",
             _ => throw new NotSupportedException($"MFA type '{simplifiedMfaName}' is not yet supported")
         };
     }
@@ -45,8 +45,8 @@ public class OktaMfaFactorSelector : IOktaMfaFactorSelector
     {
         return factor.FactorType switch
         {
-            "push" => new UserFriendlyFactor("Okta Verify (Push)", factor),
-            "token:software:totp" => new UserFriendlyFactor("Okta Verify (TOTP Code)", factor),
+            "push" => new UserFriendlyFactor("Okta Verify (Push / Fingerprint)", factor),
+            "token:software:totp" => new UserFriendlyFactor("Okta Verify (App / TOTP Code)", factor),
             _ => new UserFriendlyFactor($"[grey]{factor.FactorType} (Unsupported)[/]", factor)
         };
     }

--- a/src/Ellosoft.AwsCredentialsManager/Services/Okta/Interactive/OktaMfaFactorSelector.cs
+++ b/src/Ellosoft.AwsCredentialsManager/Services/Okta/Interactive/OktaMfaFactorSelector.cs
@@ -34,8 +34,8 @@ public class OktaMfaFactorSelector : IOktaMfaFactorSelector
     {
         return simplifiedMfaName.ToLowerInvariant() switch
         {
-            "push" or "fingerprint" => "push",
-            "totp" or "code" or "app" => "token:software:totp",
+            "push" => "push",
+            "totp" or "code" => "token:software:totp",
             "token:software:totp" => "token:software:totp",
             _ => throw new NotSupportedException($"MFA type '{simplifiedMfaName}' is not yet supported")
         };
@@ -45,8 +45,8 @@ public class OktaMfaFactorSelector : IOktaMfaFactorSelector
     {
         return factor.FactorType switch
         {
-            "push" => new UserFriendlyFactor("Okta Verify (Push / Fingerprint)", factor),
-            "token:software:totp" => new UserFriendlyFactor("Okta Verify (App / TOTP Code)", factor),
+            "push" => new UserFriendlyFactor("Okta Verify (Push)", factor),
+            "token:software:totp" => new UserFriendlyFactor("Okta Verify (TOTP Code)", factor),
             _ => new UserFriendlyFactor($"[grey]{factor.FactorType} (Unsupported)[/]", factor)
         };
     }

--- a/test/Ellosoft.AwsCredentialsManager.Tests/Services/AWS/AwsOktaSessionManagerTests.cs
+++ b/test/Ellosoft.AwsCredentialsManager.Tests/Services/AWS/AwsOktaSessionManagerTests.cs
@@ -1,0 +1,112 @@
+// Copyright (c) 2024 Ellosoft Limited. All rights reserved.
+
+using Amazon.Runtime;
+using Ellosoft.AwsCredentialsManager.Services.AWS;
+using Ellosoft.AwsCredentialsManager.Services.AWS.Interactive;
+using Ellosoft.AwsCredentialsManager.Services.Configuration.Interactive;
+using Ellosoft.AwsCredentialsManager.Services.Configuration.Models;
+using Ellosoft.AwsCredentialsManager.Services.Okta;
+using Ellosoft.AwsCredentialsManager.Services.Okta.Interactive;
+using Ellosoft.AwsCredentialsManager.Services.Okta.Models;
+using NSubstitute;
+
+namespace Ellosoft.AwsCredentialsManager.Tests.Services.AWS;
+
+public class AwsOktaSessionManagerTests
+{
+    private const string CredentialProfile = "prod";
+    private const string AwsProfile = "default";
+    private const string RoleArn = "arn:aws:iam::123:role/TestRole";
+    private const string IdpArn = "arn:aws:iam::123456:saml-provider/okta";
+    private const string OktaProfile = "default";
+    private const string OktaAppUrl = "https://xyz.okta.com/home/amazon_aws/abc/272";
+
+    private readonly ICredentialsManager _credentialsManager = Substitute.For<ICredentialsManager>();
+    private readonly IOktaLoginService _loginService = Substitute.For<IOktaLoginService>();
+    private readonly IOktaSamlService _oktaSamlService = Substitute.For<IOktaSamlService>();
+    private readonly IAwsCredentialsService _awsCredentialsService = Substitute.For<IAwsCredentialsService>();
+    private readonly IAwsSamlService _awsSamlService = Substitute.For<IAwsSamlService>();
+    private readonly AwsOktaSessionManager _sessionManager;
+
+    public AwsOktaSessionManagerTests()
+    {
+        _sessionManager = new AwsOktaSessionManager(
+            _credentialsManager,
+            _loginService,
+            _oktaSamlService,
+            _awsCredentialsService,
+            _awsSamlService);
+
+        var credentialsConfig = new CredentialsConfiguration
+        {
+            RoleArn = RoleArn,
+            AwsProfile = AwsProfile,
+            OktaProfile = OktaProfile,
+            OktaAppUrl = OktaAppUrl
+        };
+
+        _credentialsManager.TryGetCredential(CredentialProfile, out Arg.Any<CredentialsConfiguration?>())
+            .Returns(x =>
+            {
+                x[1] = credentialsConfig;
+
+                return true;
+            });
+    }
+
+    [Fact]
+    public async Task CreateOrResumeSessionAsync_WhenCachedCredentialsValid_ShouldResumeWithoutLogin()
+    {
+        var cached = CreateCachedCredentials(DateTime.Now.AddHours(2));
+        _awsCredentialsService.GetCredentialsFromStore(AwsProfile).Returns(cached);
+
+        var result = await _sessionManager.CreateOrResumeSessionAsync(CredentialProfile, AwsProfile);
+
+        result.ShouldNotBeNull();
+        result.ShouldBeOfType<SessionAWSCredentials>();
+        await _loginService.DidNotReceive().InteractiveLogin(Arg.Any<string>(), Arg.Any<bool>());
+        await _awsCredentialsService.DidNotReceive().GetAwsCredentials(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>());
+    }
+
+    [Fact]
+    public async Task CreateOrResumeSessionAsync_WhenForceRenew_ShouldLoginEvenIfCacheValid()
+    {
+        var cached = CreateCachedCredentials(DateTime.Now.AddHours(2));
+        _awsCredentialsService.GetCredentialsFromStore(AwsProfile).Returns(cached);
+
+        var oktaDomain = new Uri("https://xyz.okta.com/");
+        _loginService.InteractiveLogin(OktaProfile).Returns(new AuthenticationResult
+        {
+            OktaDomain = oktaDomain,
+            Authenticated = true,
+            SessionToken = "session-token"
+        });
+
+        _oktaSamlService.GetAppSamlDataAsync(oktaDomain, OktaAppUrl, "session-token")
+            .Returns(new SamlData("saml-assertion", "https://signin.aws.amazon.com", "relay"));
+
+        _awsSamlService.GetAwsRolesAndIdpFromSamlAssertion("saml-assertion")
+            .Returns(new Dictionary<string, string> { [RoleArn] = IdpArn });
+
+        var freshCredentials = new AwsCredentialsData(
+            "NEW_KEY",
+            "new-secret",
+            "new-token",
+            DateTime.Now.AddHours(2),
+            RoleArn);
+
+        _awsCredentialsService.GetAwsCredentials("saml-assertion", RoleArn, IdpArn)
+            .Returns(freshCredentials);
+
+        var result = await _sessionManager.CreateOrResumeSessionAsync(CredentialProfile, AwsProfile, forceRenew: true);
+
+        result.ShouldNotBeNull();
+        await _loginService.Received(1).InteractiveLogin(OktaProfile);
+        await _awsCredentialsService.Received(1).GetAwsCredentials("saml-assertion", RoleArn, IdpArn);
+        _awsCredentialsService.Received(1).StoreCredentials(AwsProfile, freshCredentials);
+    }
+
+    private static AwsCredentialsData CreateCachedCredentials(DateTime expiration) =>
+        new("CACHED_KEY", "cached-secret", "cached-token", expiration, RoleArn);
+}

--- a/test/Ellosoft.AwsCredentialsManager.Tests/Services/Okta/OktaMfaFactorSelectorTests.cs
+++ b/test/Ellosoft.AwsCredentialsManager.Tests/Services/Okta/OktaMfaFactorSelectorTests.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2024 Ellosoft Limited. All rights reserved.
+
+using Ellosoft.AwsCredentialsManager.Services.Okta.Interactive;
+
+namespace Ellosoft.AwsCredentialsManager.Tests.Services.Okta;
+
+public class OktaMfaFactorSelectorTests
+{
+    [Theory]
+    [InlineData("push", "push")]
+    [InlineData("fingerprint", "push")]
+    [InlineData("PUSH", "push")]
+    [InlineData("Fingerprint", "push")]
+    [InlineData("totp", "token:software:totp")]
+    [InlineData("code", "token:software:totp")]
+    [InlineData("app", "token:software:totp")]
+    [InlineData("APP", "token:software:totp")]
+    [InlineData("token:software:totp", "token:software:totp")]
+    public void GetOktaMfaFactorCode_SupportedValues_ShouldNormalize(string input, string expected)
+    {
+        var result = OktaMfaFactorSelector.GetOktaMfaFactorCode(input);
+
+        result.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("sms")]
+    [InlineData("duo")]
+    [InlineData("signed_nonce")]
+    [InlineData("")]
+    public void GetOktaMfaFactorCode_UnsupportedValues_ShouldThrow(string input)
+    {
+        var act = () => OktaMfaFactorSelector.GetOktaMfaFactorCode(input!);
+
+        Should.Throw<NotSupportedException>(act)
+            .Message.ShouldContain(input!);
+    }
+}

--- a/test/Ellosoft.AwsCredentialsManager.Tests/Services/Okta/OktaMfaFactorSelectorTests.cs
+++ b/test/Ellosoft.AwsCredentialsManager.Tests/Services/Okta/OktaMfaFactorSelectorTests.cs
@@ -8,13 +8,9 @@ public class OktaMfaFactorSelectorTests
 {
     [Theory]
     [InlineData("push", "push")]
-    [InlineData("fingerprint", "push")]
     [InlineData("PUSH", "push")]
-    [InlineData("Fingerprint", "push")]
     [InlineData("totp", "token:software:totp")]
     [InlineData("code", "token:software:totp")]
-    [InlineData("app", "token:software:totp")]
-    [InlineData("APP", "token:software:totp")]
     [InlineData("token:software:totp", "token:software:totp")]
     public void GetOktaMfaFactorCode_SupportedValues_ShouldNormalize(string input, string expected)
     {
@@ -27,6 +23,8 @@ public class OktaMfaFactorSelectorTests
     [InlineData("sms")]
     [InlineData("duo")]
     [InlineData("signed_nonce")]
+    [InlineData("fingerprint")]
+    [InlineData("app")]
     [InlineData("")]
     public void GetOktaMfaFactorCode_UnsupportedValues_ShouldThrow(string input)
     {


### PR DESCRIPTION
## Summary
- Normalize MFA type matching case-insensitively and accept the raw Okta factor `token:software:totp` alongside `push` / `totp` / `code`
- Add `--force-renew` to `cred get` and `rds pwd` so AWS sessions can be refreshed even when the cache is still valid
- Document the flag and cover MFA normalization plus force-renew session behavior with unit tests

## Test plan
- [ ] `dotnet test` (unit tests for `OktaMfaFactorSelector` and `AwsOktaSessionManager` force-renew path)
- [ ] With a still-valid cached AWS session, `aws-cred-mgr cred get <profile>` reuses it
- [ ] With a valid cached session, `aws-cred-mgr cred get <profile> --force-renew` re-authenticates and stores new credentials
- [ ] `rds pwd ... --force-renew` likewise forces a fresh session
- [ ] `preferred_mfa_type: push|totp|code` continues to work as before